### PR TITLE
Fix naming override

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
         "url": "https://github.com/mdanka/momo-chords/issues"
     },
     "dependencies": {
-        "@types/lodash.merge": "^4.6.6",
-        "@types/node": "^12.0.0",
         "commonjs": "^0.0.1",
         "es6-shim": "^0.35.3",
         "lodash.merge": "^4.6.1"
@@ -44,7 +42,9 @@
     "devDependencies": {
         "@types/chai": "^3.4.35",
         "@types/es6-shim": "^0.31.33",
+        "@types/lodash.merge": "^4.6.6",
         "@types/mocha": "^2.2.40",
+        "@types/node": "^12.0.0",
         "awesome-typescript-loader": "^3.1.2",
         "chai": "^3.5.0",
         "karma": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,11 @@
         "url": "https://github.com/mdanka/momo-chords/issues"
     },
     "dependencies": {
+        "@types/lodash.merge": "^4.6.6",
+        "@types/node": "^12.0.0",
         "commonjs": "^0.0.1",
-        "es6-shim": "^0.35.3"
+        "es6-shim": "^0.35.3",
+        "lodash.merge": "^4.6.1"
     },
     "devDependencies": {
         "@types/chai": "^3.4.35",

--- a/src/naming.ts
+++ b/src/naming.ts
@@ -11,6 +11,8 @@ import {
     INaming,
 } from "./types";
 
+const merge = require("lodash.merge");
+
 const majorSymbols = ["maj", "major", "Maj", "M", "Δ"];
 const minorSymbols = ["m", "minor", "min", "−", "-"];
 const augmentedSymbols = ["aug", "augmented", "+"];
@@ -164,10 +166,7 @@ export class Naming {
     };
 
     public constructor(namingOverride?: Partial<INaming>) {
-        this.naming = {
-            ...DEFAULT_NAMING,
-            ...namingOverride,
-        };
+        this.naming = merge(DEFAULT_NAMING, namingOverride);
         this.names = {
             notes: new Map(this.naming.parsing.notes),
             qualities: new Map(this.naming.parsing.qualities),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,26 @@
   version "0.31.37"
   resolved "https://registry.yarnpkg.com/@types/es6-shim/-/es6-shim-0.31.37.tgz#d01fa9b61a6692e57387dde5483b0255659ba70f"
 
+"@types/lodash.merge@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
+  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.126"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.126.tgz#47cff3ea014aa083194f8ca3ec351136c3786613"
+  integrity sha512-HxQ+wQnBtnL0LszZrVdMqWIlzZNyKuMLUb6swQ3mo6ysPqpAu7gfnapCQIi0B+Mrf0fNLZh8AWgJs2njejVasg==
+
 "@types/mocha@^2.2.40":
   version "2.2.48"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
+
+"@types/node@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.0.tgz#d11813b9c0ff8aaca29f04cbc12817f4c7d656e5"
+  integrity sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==
 
 abbrev@1:
   version "1.1.1"
@@ -2224,6 +2241,11 @@ lodash.keys@^3.0.0:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
+
+lodash.merge@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
 
 lodash@^3.8.0:
   version "3.10.1"


### PR DESCRIPTION
Without this fix it does not seems possible to override namings, as the spread operator only allows for shallow merging of objects : we need deep merging here.

That said:
- this fix relies on `lodash.merge()` to do the actual merging. That solution implies to add 3 dependencies, at least if I understand well given that I have no Typescript experience: `lodash.merge`, `@type/lodash.merge` and then `@types/node` because Typescript would not allow es6 `import` of `lodash`, so `require` is needed. Alternate option would be to set `allowSyntheticDefaultImports` to [TS configuration](https://stackoverflow.com/questions/39415661/what-does-resolves-to-a-non-module-entity-and-cannot-be-imported-using-this#39415662)? Or there might be a proper way to `import` `lodash`?

- Again without knowledge of TS (which any consumer of this lib might not have either) I used the following code, which might be wrong. Maybe another syntax would work without the need for a fix? :
```
const myNaming = {
	printing: {
		addeds: [
			['Add9', '2'],
			['Add11', '4'],
			['Add13', '6'],
		]
	}
};

const chords = new Chords(myNaming);
```

- finally without a contributor guide I'm not sure what should be done here: version bump, bundling, etc. Maybe that's opportunity to define exactly what is expected and add that to the Readme?

Thanks !